### PR TITLE
feat: ALLOW_DEV_SIGN_IN env로 prod devSignIn 활성화 허용

### DIFF
--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -4,7 +4,10 @@ module Types
   class MutationType < Types::BaseObject
     # Authentication
     field :sign_in_with_apple, mutation: Mutations::SignInWithApple
-    if Rails.env.development? || Rails.env.test?
+    # Also register when explicitly enabled via env (e.g. personal prod for
+    # Flutter dev where Sign in with Apple is unavailable on the simulator).
+    # The resolver in DevSignIn already honors ALLOW_DEV_SIGN_IN.
+    if Rails.env.development? || Rails.env.test? || ENV["ALLOW_DEV_SIGN_IN"] == "true"
       field :dev_sign_in, mutation: Mutations::DevSignIn
       field :dev_sign_in_fresh, mutation: Mutations::DevSignInFresh
     end


### PR DESCRIPTION
## 배경
Flutter 프론트엔드를 새로 개발 중인데, iOS 시뮬레이터에서 Sign in with Apple이 호스트 anisette 인증 손상으로 동작하지 않아 **prod 로그인이 불가능**한 상황.

prod의 유일한 로그인 수단이 `signInWithApple` 뿐이라 개발이 막힘.

## 변경
`mutation_type.rb`의 devSignIn 필드 등록 조건에 `|| ENV["ALLOW_DEV_SIGN_IN"] == "true"` 추가.

- `DevSignIn` resolver는 **이미** `ALLOW_DEV_SIGN_IN`을 지원하고 있었으나, 필드 등록부가 `development?/test?`만 체크해서 prod에선 필드 자체가 노출 안 됨 → env 탈출구가 무효였던 갭을 메움.

## 배포 후 활성화
Railway에 환경변수 설정:
```
ALLOW_DEV_SIGN_IN=true
```

## 보안
- 개인용 prod 한정. 플래그를 빼면 즉시 비활성화.
- 정식 출시 전 반드시 제거 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)