### PR TITLE
fix: lib/simulation eager-load 제외 — prod 부팅 크래시 해결

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,10 @@ module RepstackBackend
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    # `simulation` is a dev/test harness loaded on demand by rake tasks
+    # (lib/tasks/simulation.rake); it must not be eager loaded at boot — its
+    # runner.rb require_relatives several uncommitted files and crashes boot.
+    config.autoload_lib(ignore: %w[assets tasks simulation])
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
## 문제
prod 배포 시 부팅 크래시:
```
LoadError: cannot load such file -- /rails/lib/simulation/day_simulator
lib/simulation/runner.rb:4:in require_relative
```

`config.autoload_lib(ignore: %w[assets tasks])`가 `lib/` 전체를 eager-load하면서, `lib/simulation/runner.rb`가 **커밋된 적 없는 파일 5개**(day_simulator, error_logger, report_generator, personas/normal_user, personas/power_user)를 `require_relative`해 부팅이 죽었음.

`fff2608`부터 잠재해 있었으나 그동안 redeploy가 없어 옛 컨테이너로 연명 중이었고, 이번 배포에서 처음 드러남.

## 수정
`simulation`을 autoload_lib ignore에 추가. 이 디렉토리는 `lib/tasks/simulation.rake`가 필요할 때만 `require_relative`로 로드하는 하니스라 eager-load 대상이 아님.

## 검증
railway up 배포 후 부팅 성공 + GraphQL 정상 응답 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)