### PR TITLE
fix: AiExerciseType#target_muscle_name 500 해결

### DIFF
--- a/app/graphql/types/ai_exercise_type.rb
+++ b/app/graphql/types/ai_exercise_type.rb
@@ -46,11 +46,12 @@ module Types
 
     def target_muscle_name
       locale = context[:locale] || "ko"
+      tm = object.is_a?(Hash) ? (object[:target_muscle] || object["target_muscle"]) : object.target_muscle
       if locale == "ko"
         val = object.is_a?(Hash) ? (object[:target_muscle_korean] || object["target_muscle_korean"]) : nil
-        val || target_muscle
+        val || tm
       else
-        target_muscle
+        tm
       end
     end
   end


### PR DESCRIPTION
## 문제
chat 쿼리에서 `routine.exercises.targetMuscleName`를 요청하면 500:
```
NameError: undefined local variable or method 'target_muscle' for an instance of Types::AiExerciseType
app/graphql/types/ai_exercise_type.rb:51
```
`target_muscle_name`이 `object`에서 읽지 않고 맨 변수 `target_muscle`를 참조함.

## 수정
`object`(Hash 또는 객체)에서 `target_muscle`를 일관되게 읽도록 변경.

## 검증
railway up 배포 후 앱이 보내는 전체 Chat 쿼리 정상 응답 확인 (`targetMuscleName` = "legs").

🤖 Generated with [Claude Code](https://claude.com/claude-code)