### PR TITLE
fix: deleteWorkoutSet 동작 (success null + active 제약)

### DIFF
--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -30,10 +30,13 @@ module Mutations
 
     # Build a standard error response hash
     # @param errors [Array<String>, String] - error message(s)
-    # @param fields [Hash] - additional fields to include (all set to nil)
+    # @param fields [Hash] - additional fields to include, kept as-is
     def error_response(errors, **fields)
       errors = Array(errors)
-      fields.transform_values { nil }.merge(errors: errors)
+      # Keep caller-provided values as-is. Callers pass the exact error-state
+      # value they want (e.g. success: false, workout_set: nil); nil-ing them
+      # broke non-nullable fields like DeleteWorkoutSetPayload.success.
+      fields.merge(errors: errors)
     end
 
     # Build a standard success response hash

--- a/app/graphql/mutations/delete_workout_set.rb
+++ b/app/graphql/mutations/delete_workout_set.rb
@@ -18,8 +18,9 @@ module Mutations
           .find_by(id: set_id)
 
         return error_response("Set not found", success: false) unless workout_set
-        return error_response("Session is not active", success: false) unless workout_set.workout_session.active?
 
+        # Allow deleting any of the user's own sets so the log stays editable
+        # (not just active-session undo). Ownership is enforced by the scope above.
         workout_set.destroy!
         success_response(success: true)
       end


### PR DESCRIPTION
error_response가 success: false를 nil로 만들어 non-nullable 위반 → 그대로 유지하도록 수정. 또한 로그 편집을 위해 active 세션 제약 제거. railway up 배포 후 deleteWorkoutSet success:true 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)